### PR TITLE
Fix FileRecvRedirect on Android 11

### DIFF
--- a/app/src/main/java/nil/nadph/qnotified/hook/FileRecvRedirect.java
+++ b/app/src/main/java/nil/nadph/qnotified/hook/FileRecvRedirect.java
@@ -91,7 +91,7 @@ public class FileRecvRedirect extends BaseDelayableHook {
         if (isTim(getApplication())) {
             return Environment.getExternalStorageDirectory().getAbsolutePath() + "/Tencent/TIMfile_recv/";
         } else {
-                return "/mnt/sdcard/Android/data/com.tencent.mobileqq/Tencent/QQfile_recv/";
+                return "/storage/self/primary/Android/data/com.tencent.mobileqq/Tencent/QQfile_recv/";
             }
     }
 

--- a/app/src/main/java/nil/nadph/qnotified/hook/FileRecvRedirect.java
+++ b/app/src/main/java/nil/nadph/qnotified/hook/FileRecvRedirect.java
@@ -29,6 +29,7 @@ import nil.nadph.qnotified.step.DexDeobfStep;
 import nil.nadph.qnotified.step.Step;
 import nil.nadph.qnotified.util.DexKit;
 import nil.nadph.qnotified.util.Nullable;
+import me.singleneuron.util.QQVersion;
 
 import static nil.nadph.qnotified.util.Utils.*;
 
@@ -88,14 +89,10 @@ public class FileRecvRedirect extends BaseDelayableHook {
 
     public String getDefaultPath() {
         if (isTim(getApplication())) {
-            return Environment.getExternalStorageDirectory().getAbsolutePath() + "/Tencent/TIMfile_recv/";
+            return "/mnt/sdcard/Android/data/com.tencent.tim/Tencent/TIMfile_recv/";
         } else {
-            if (getHostVersionCode32() > 1334) {
-                return getApplication().getExternalFilesDir(null) + "/Tencent/QQfile_recv/";
-            } else {
-                return Environment.getExternalStorageDirectory().getAbsolutePath() + "/Tencent/QQfile_recv/";
+                return "/mnt/sdcard/Android/data/com.tencent.mobileqq/Tencent/QQfile_recv/";
             }
-        }
     }
 
     @Nullable

--- a/app/src/main/java/nil/nadph/qnotified/hook/FileRecvRedirect.java
+++ b/app/src/main/java/nil/nadph/qnotified/hook/FileRecvRedirect.java
@@ -29,7 +29,6 @@ import nil.nadph.qnotified.step.DexDeobfStep;
 import nil.nadph.qnotified.step.Step;
 import nil.nadph.qnotified.util.DexKit;
 import nil.nadph.qnotified.util.Nullable;
-import me.singleneuron.util.QQVersion;
 
 import static nil.nadph.qnotified.util.Utils.*;
 

--- a/app/src/main/java/nil/nadph/qnotified/hook/FileRecvRedirect.java
+++ b/app/src/main/java/nil/nadph/qnotified/hook/FileRecvRedirect.java
@@ -89,7 +89,7 @@ public class FileRecvRedirect extends BaseDelayableHook {
 
     public String getDefaultPath() {
         if (isTim(getApplication())) {
-            return "/mnt/sdcard/Android/data/com.tencent.tim/Tencent/TIMfile_recv/";
+            return Environment.getExternalStorageDirectory().getAbsolutePath() + "/Tencent/TIMfile_recv/";
         } else {
                 return "/mnt/sdcard/Android/data/com.tencent.mobileqq/Tencent/QQfile_recv/";
             }


### PR DESCRIPTION
## 介绍 / Description

在Android 11上，/storage/emulated/0/Android/data目录不允许被访问，所以我们需要另辟蹊径。

## 更改内容 / Types of Changes

- [x] 修复 Bugfix

## 检查列表 / Checklist

- [x] 我的代码符合本仓库的代码规范 My code follows the code style of this project
- [x] 我已经测试了这些更改，它们可以正常工作，且不会破坏任何功能(或我可以解决) I have tested the changes and verified that they work and don't break anything (as well as I can manage).
- [x] 我已合并了对后续工作无意义的commit并确认不会对后续维护造成困扰 I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance