### PR TITLE
[skip ci] Roll back to 4.0.2 because AppCenter doesn't support gradle 4.1.0+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        //noinspection GradleDependency
+        classpath 'com.android.tools.build:gradle:4.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Usage of Android Gradle Plugin 4.1.0+ is not supported at the moment. Please use any of the earlier versions.

## 介绍 / Description

<!--- 在此详细的描述你的更改 -->
<!--- Describe your changes in detail here. -->
![image](https://user-images.githubusercontent.com/40174090/103435845-83a9c200-4c4f-11eb-8e6d-ca8f57090899.png)


## 更改内容 / Types of Changes
<!--- 你的代码更改了哪部分的内容？在下方的方框里输入x-->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [x] Script & build config

## 由这个PR解决或关闭的Issues / Issues Fixed or Closed by This PR

-  None

## 检查列表 / Checklist

<!--- 遍历以下所有点并在下方的方框里输入x以生效-->
<!--- 如果你不确定，请不要犹豫，我们会为你提供帮助-->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] 我的代码符合本仓库的代码规范 My code follows the code style of this project
- [x] 我已经测试了这些更改，它们可以正常工作，且不会破坏任何功能(或我可以解决) I have tested the changes and verified that they work and don't break anything (as well as I can manage).
- [x] 我已合并了对后续工作无意义的commit并确认不会对后续维护造成困扰 I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
