### PR TITLE
[skip ci][重大更新]Add ForcedSendOriginalPhoto.kt & EnableQLog.kt

### DIFF
--- a/app/src/main/java/me/nextalone/hook/EnableQLog.kt
+++ b/app/src/main/java/me/nextalone/hook/EnableQLog.kt
@@ -1,0 +1,92 @@
+package me.nextalone.hook
+
+import android.os.Looper
+import android.widget.Toast
+import de.robv.android.xposed.XC_MethodHook
+import de.robv.android.xposed.XposedBridge
+import me.kyuubiran.util.getMethods
+import nil.nadph.qnotified.SyncUtils
+import nil.nadph.qnotified.config.ConfigManager
+import nil.nadph.qnotified.hook.BaseDelayableHook
+import nil.nadph.qnotified.step.Step
+import nil.nadph.qnotified.util.LicenseStatus
+import nil.nadph.qnotified.util.Utils
+import java.lang.reflect.Method
+
+object EnableQLog : BaseDelayableHook() {
+    private const val na_enable_qlog: String = "na_enable_qlog"
+    var isInit = false
+    const val TAG = "NextAlone"
+    override fun getPreconditions(): Array<Step?> {
+        return arrayOfNulls(0)
+    }
+
+    override fun init(): Boolean {
+        if (isInit) return true
+        return try {
+            for (m: Method in getMethods("com.tencent.qphone.base.util.QLog")) {
+                val argt = m.parameterTypes
+                if (m.name == "isColorLevel" && argt.isEmpty()) {
+                    XposedBridge.hookMethod(m, object : XC_MethodHook() {
+                        override fun beforeHookedMethod(param: MethodHookParam) {
+                            if (LicenseStatus.sDisableCommonHooks) return
+                            if (!isEnabled) return
+                            param.result = true
+                        }
+                    })
+                }
+            }
+            for (m: Method in getMethods("com.tencent.qphone.base.util.QLog")) {
+                val argt = m.parameterTypes
+                if (m.name == "getTag" && argt.size == 1 && argt[0] == String::class.java) {
+                    XposedBridge.hookMethod(m, object : XC_MethodHook() {
+                        override fun afterHookedMethod(param: MethodHookParam) {
+                            if (LicenseStatus.sDisableCommonHooks) return
+                            if (!isEnabled) return
+                            val tag = param.args[0]
+                            param.result = "NAdump $tag"
+                        }
+                    })
+                }
+            }
+
+            isInit = true
+            true
+        } catch (t: Throwable) {
+            Utils.log(t)
+            false
+        }
+    }
+
+    override fun isEnabled(): Boolean {
+        return try {
+            ConfigManager.getDefaultConfig().getBooleanOrFalse(na_enable_qlog)
+        } catch (e: java.lang.Exception) {
+            Utils.log(e)
+            false
+        }
+    }
+
+    override fun getEffectiveProc(): Int {
+        return SyncUtils.PROC_MAIN
+    }
+
+    override fun setEnabled(enabled: Boolean) {
+        try {
+            val mgr = ConfigManager.getDefaultConfig()
+            mgr.allConfig[na_enable_qlog] = enabled
+            mgr.save()
+        } catch (e: Exception) {
+            Utils.log(e)
+            if (Looper.myLooper() == Looper.getMainLooper()) {
+                Utils.showToast(Utils.getApplication(), Utils.TOAST_TYPE_ERROR, e.toString() + "", Toast.LENGTH_SHORT)
+            } else {
+                SyncUtils.post { Utils.showToast(Utils.getApplication(), Utils.TOAST_TYPE_ERROR, e.toString() + "", Toast.LENGTH_SHORT) }
+            }
+        }
+    }
+
+    override fun isInited(): Boolean {
+        return isInit
+    }
+}

--- a/app/src/main/java/me/nextalone/hook/ForcedSendOriginalPhoto.kt
+++ b/app/src/main/java/me/nextalone/hook/ForcedSendOriginalPhoto.kt
@@ -1,0 +1,83 @@
+package me.nextalone.hook
+
+import android.os.Looper
+import android.view.View
+import android.widget.CheckBox
+import android.widget.Toast
+import de.robv.android.xposed.XC_MethodHook
+import de.robv.android.xposed.XposedBridge
+import me.kyuubiran.util.getMethods
+import me.singleneuron.qn_kernel.tlb.ConfigTable
+import nil.nadph.qnotified.SyncUtils
+import nil.nadph.qnotified.config.ConfigManager
+import nil.nadph.qnotified.hook.BaseDelayableHook
+import nil.nadph.qnotified.step.Step
+import nil.nadph.qnotified.util.LicenseStatus
+import nil.nadph.qnotified.util.Utils
+import java.lang.reflect.Method
+
+object ForcedSendOriginalPhoto : BaseDelayableHook() {
+    private const val na_test_forced_original: String = "na_test_forced_original"
+    var isInit = false
+
+    override fun getPreconditions(): Array<Step?> {
+        return arrayOfNulls(0)
+    }
+
+    override fun init(): Boolean {
+        if (isInit) return true
+        return try {
+            for (m: Method in getMethods("com.tencent.mobileqq.activity.aio.photo.PhotoListPanel")) {
+                val argt = m.parameterTypes
+                if (m.name == "a" && argt.size == 1 && argt[0] == Boolean::class.java) {
+                    XposedBridge.hookMethod(m, object : XC_MethodHook() {
+                        override fun afterHookedMethod(param: MethodHookParam?) {
+                            if (LicenseStatus.sDisableCommonHooks) return
+                            if (!isEnabled) return
+                            val ctx = param!!.thisObject as View
+                            val sendOriginPhotoCheckbox: CheckBox = ctx.findViewById(ConfigTable.getConfig(ForcedSendOriginalPhoto::class.simpleName))
+                            sendOriginPhotoCheckbox.isChecked = true
+                        }
+                    })
+                }
+            }
+            isInit = true
+            true
+        } catch (t: Throwable) {
+            Utils.log(t)
+            false
+        }
+    }
+
+    override fun isEnabled(): Boolean {
+        return try {
+            ConfigManager.getDefaultConfig().getBooleanOrFalse(na_test_forced_original)
+        } catch (e: java.lang.Exception) {
+            Utils.log(e)
+            false
+        }
+    }
+
+    override fun getEffectiveProc(): Int {
+        return SyncUtils.PROC_MAIN
+    }
+
+    override fun setEnabled(enabled: Boolean) {
+        try {
+            val mgr = ConfigManager.getDefaultConfig()
+            mgr.allConfig[na_test_forced_original] = enabled
+            mgr.save()
+        } catch (e: Exception) {
+            Utils.log(e)
+            if (Looper.myLooper() == Looper.getMainLooper()) {
+                Utils.showToast(Utils.getApplication(), Utils.TOAST_TYPE_ERROR, e.toString() + "", Toast.LENGTH_SHORT)
+            } else {
+                SyncUtils.post { Utils.showToast(Utils.getApplication(), Utils.TOAST_TYPE_ERROR, e.toString() + "", Toast.LENGTH_SHORT) }
+            }
+        }
+    }
+
+    override fun isInited(): Boolean {
+        return isInit
+    }
+}

--- a/app/src/main/java/me/singleneuron/qn_kernel/tlb/ConfigTable.kt
+++ b/app/src/main/java/me/singleneuron/qn_kernel/tlb/ConfigTable.kt
@@ -1,5 +1,6 @@
 package me.singleneuron.qn_kernel.tlb
 
+import me.nextalone.hook.ForcedSendOriginalPhoto
 import me.nextalone.hook.HideProfileBubble
 import me.singleneuron.hook.ChangeDrawerWidth
 import me.singleneuron.hook.ForceSystemCamera
@@ -69,7 +70,12 @@ object ConfigTable {
                     QQVersion.QQ_8_4_1 to "azfl",
                     QQVersion.QQ_8_4_5 to "azxy",
                     QQVersion.QQ_8_4_8 to "aymn"
+            ),
+
+            ForcedSendOriginalPhoto::class.java.simpleName to mapOf(
+                    QQVersion.QQ_8_5_0 to 2131375226
             )
+
     )
 
     fun <T> getConfig(className: String?): T {

--- a/app/src/main/java/nil/nadph/qnotified/activity/BetaTestFuncActivity.java
+++ b/app/src/main/java/nil/nadph/qnotified/activity/BetaTestFuncActivity.java
@@ -27,6 +27,7 @@ import android.widget.TextView;
 import com.tencent.mobileqq.widget.BounceScrollView;
 import me.kyuubiran.hook.RemoveRedDot;
 import me.kyuubiran.hook.testhook.CutMessage;
+import me.nextalone.hook.ForcedSendOriginalPhoto;
 import nil.nadph.qnotified.hook.ChatTailHook;
 import nil.nadph.qnotified.hook.MutePokePacket;
 import nil.nadph.qnotified.hook.PttForwardHook;
@@ -81,7 +82,7 @@ public class BetaTestFuncActivity extends IphoneTitleBarActivityCompat {
                 public void run() {
                     try {
                         Thread.sleep(3000);
-                        BetaTestFuncActivity.this.finish();
+                        finish();
                     } catch (InterruptedException e) {
                         e.printStackTrace();
                     }
@@ -91,6 +92,7 @@ public class BetaTestFuncActivity extends IphoneTitleBarActivityCompat {
             ll.addView(subtitle(this, "Beta测试功能 仅用于测试稳定性[可能会存在BUG 包括但不限于功能不生效、" + _hostName + "出现卡顿乃至" + _hostName + "闪退 请酌情开启]"));
             ll.addView(newListItemSwitchConfig(this, "保存语音", "需要打开语音转发才能使用本功能", PttForwardHook.qn_enable_ptt_save, false));
             ll.addView(newListItemHookSwitchInit(this, "移除小红点", "仅供测试", RemoveRedDot.INSTANCE));
+            ll.addView(newListItemHookSwitchInit(this, "聊天自动发送原图", "仅供测试", ForcedSendOriginalPhoto.INSTANCE));
             ll.addView(_t = newListItemButton(this, "自定义聊天小尾巴", "回车发送不生效", "N/A", clickToProxyActAction(ACTION_CHAT_TAIL_CONFIG_ACTIVITY)));
             __tv_chat_tail_status = _t.findViewById(R_ID_VALUE);
             ll.addView(newListItemHookSwitchInit(this, "屏蔽戳一戳", "OvO", MutePokePacket.get()));
@@ -100,7 +102,7 @@ public class BetaTestFuncActivity extends IphoneTitleBarActivityCompat {
             __js_status = __t.findViewById(R_ID_VALUE);
         }
         __ll.setLayoutParams(new ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT));
-        this.setContentView(bounceScrollView);
+        setContentView(bounceScrollView);
         LinearLayout.LayoutParams _lp_fat = new LinearLayout.LayoutParams(MATCH_PARENT, 0);
         _lp_fat.weight = 1;
 

--- a/app/src/main/java/nil/nadph/qnotified/hook/BaseDelayableHook.java
+++ b/app/src/main/java/nil/nadph/qnotified/hook/BaseDelayableHook.java
@@ -20,6 +20,8 @@ package nil.nadph.qnotified.hook;
 
 import me.kyuubiran.hook.*;
 import me.kyuubiran.hook.testhook.CutMessage;
+import me.nextalone.hook.EnableQLog;
+import me.nextalone.hook.ForcedSendOriginalPhoto;
 import me.nextalone.hook.HideProfileBubble;
 import me.nextalone.hook.RemoveIntimateDrawer;
 import me.singleneuron.hook.*;
@@ -121,6 +123,8 @@ public abstract class BaseDelayableHook implements SwitchConfigItem {
                 RemoveDailySign.INSTANCE,
                 RemoveFuckingDiyCard.INSTANCE,
                 RemoveRedDot.INSTANCE,
+                EnableQLog.INSTANCE,
+                ForcedSendOriginalPhoto.INSTANCE
         };
         return sAllHooks;
     }


### PR DESCRIPTION
Signed-off-by: NextAlone <12210746+NextAlone@users.noreply.github.com>

# 新增聊天自动发送原图(仅8.5.0) 新增记录QQ的Log

## 介绍 / Description

- 在 **展望未来** 中隐藏了自动发送原图
- PlusPanelIcon弹出的图片未Hook
- 长按PhotoPanelIcon直接打开相册未Hook
- 记录QQ Log 供新增功能调试使用（位于故障排查中），前缀NAdump，与QNdump区分

## 更改内容 / Types of Changes
<!--- 你的代码更改了哪部分的内容？在下方的方框里输入x-->
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] 内核 Core
- [ ] 修复 Bugfix
- [x] 新功能 New feature
- [ ] 增强/优化 Enhancement/optimization
- [ ] 文档 Documentation
- [ ] UI界面 User interface

## 由这个PR解决或关闭的Issues / Issues Fixed or Closed by This PR

-  None

## 检查列表 / Checklist

- [x] 我的代码符合本仓库的代码规范 My code follows the code style of this project
- [x] 我已经测试了这些更改，它们可以正常工作，且不会破坏任何功能(或我可以解决) I have tested the changes and verified that they work and don't break anything (as well as I can manage).
- [ ] 我已合并了对后续工作无意义的commit并确认不会对后续维护造成困扰 I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
