### PR TITLE
Add direct-accessible package name cache

### DIFF
--- a/app/src/main/java/nil/nadph/qnotified/HookEntry.java
+++ b/app/src/main/java/nil/nadph/qnotified/HookEntry.java
@@ -50,20 +50,21 @@ public class HookEntry implements IXposedHookLoadPackage {
             return;
         }
         //dumpProcessInfo(lpparam.isFirstApplication);
-        //noinspection AlibabaSwitchStatement
         switch (lpparam.packageName) {
-            case PACKAGE_NAME_SELF:
+            case PACKAGE_NAME_SELF: {
                 XposedHelpers.findAndHookMethod("nil.nadph.qnotified.util.Utils", lpparam.classLoader, "getActiveModuleVersion", XC_MethodReplacement.returnConstant(Utils.QN_VERSION_NAME));
                 break;
+            }
             case PACKAGE_NAME_TIM:
-                Utils.IS_TIM = true;
-            case PACKAGE_NAME_QQ:
+            case PACKAGE_NAME_QQ: {
                 StartupHook.getInstance().doInit(lpparam.classLoader);
                 break;
+            }
             case PACKAGE_NAME_QQ_INTERNATIONAL:
-            case PACKAGE_NAME_QQ_LITE:
+            case PACKAGE_NAME_QQ_LITE: {
                 //coming...
                 break;
+            }
             default:
                 break;
         }

--- a/app/src/main/java/nil/nadph/qnotified/StartupHook.java
+++ b/app/src/main/java/nil/nadph/qnotified/StartupHook.java
@@ -88,6 +88,7 @@ public class StartupHook {
                         }
                         System.setProperty(QN_FULL_TAG, "true");
                         Initiator.init(classLoader);
+                        Utils.sInit(ctx);
                         try {
                             Natives.load(ctx);
                         } catch (Throwable e3) {

--- a/app/src/main/java/nil/nadph/qnotified/util/Utils.java
+++ b/app/src/main/java/nil/nadph/qnotified/util/Utils.java
@@ -74,10 +74,22 @@ public class Utils {
     public static boolean DEBUG = true;
     public static boolean ENABLE_DUMP_LOG = false;
     private static Handler mHandler;
+    public static String sHostPackageName = null;
     public static boolean IS_TIM = false;
+    public static boolean IS_QQ = false;
 
     private Utils() {
         throw new AssertionError("No instance for you!");
+    }
+
+    public static void sInit(@NonNull Context ctx) {
+        if (sHostPackageName != null) {
+            throw new IllegalStateException("re-init Utils");
+        } else {
+            sHostPackageName = ctx.getPackageName();
+            IS_QQ = PACKAGE_NAME_QQ.equals(sHostPackageName);
+            IS_TIM = PACKAGE_NAME_TIM.equals(sHostPackageName);
+        }
     }
 
     @Nullable


### PR DESCRIPTION
Signed-off-by: Null Idle <xenonhydride@gmail.com>

## 介绍 / Description
 - Add direct-accessible package name cache
 - 缓存改为 field 以直接访问 IS_TIM, IS_QQ, sHostPackageName
 - Fix SonarLint warning: remove the static access from an instance method.


## 更改内容 / Types of Changes
- 增强优化 Enhancement/optimization


## 检查列表 / Checklist
- [x] 我的代码符合本仓库的代码规范 My code follows the code style of this project
- [x] 我已经测试了这些更改，它们可以正常工作，既不会破坏原有任何功能(或我可以解决)，也不会影响对旧版本的支持 I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] 我已合并了对后续工作无意义的commit并确认不会对后续维护造成困扰 I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
