### PR TITLE
Add mute troop at all msg in AntiMessage and remove sth in SettingsActivity

### DIFF
--- a/app/src/main/java/cn/lliiooll/hook/AntiMessage.kt
+++ b/app/src/main/java/cn/lliiooll/hook/AntiMessage.kt
@@ -39,6 +39,9 @@ object AntiMessage : MultiItemDelayableHook("qn_anti_message_items", "屏蔽"), 
         if (items.contains(data?.msgType)) {
             XposedHelpers.setBooleanField(data?.msgRecord, "isread", true)
             return true
+        } else if (items.contains(0) and (data?.msg?.contains("@全体成员") == true)) {
+            XposedHelpers.setBooleanField(data?.msgRecord, "isread", true)
+            return true
         }
         return false
     }

--- a/app/src/main/java/cn/lliiooll/util/MsgRecordUtil.java
+++ b/app/src/main/java/cn/lliiooll/util/MsgRecordUtil.java
@@ -28,6 +28,7 @@ import org.jetbrains.annotations.Nullable;
 public class MsgRecordUtil {
 
     public static final BiMap<String, Integer> MSG = new HashBiMap<String, Integer>() {{
+        put("@全体消息", 0);
         put("EXTRA_STREAM_PTT_FLAG", 10001);
         put("MIN_VERSION_CODE_SUPPORT_IMAGE_MD5_TRANS", 2);
         put("MSG_TYPE_0X7F", -2006);

--- a/app/src/main/java/nil/nadph/qnotified/activity/SettingsActivity.java
+++ b/app/src/main/java/nil/nadph/qnotified/activity/SettingsActivity.java
@@ -186,14 +186,6 @@ public class SettingsActivity extends IphoneTitleBarActivityCompat implements Ru
         ll.addView(newListItemHookSwitchInit(this, "禁用$打开送礼界面", "禁止聊天时输入$自动弹出[选择赠送对象]窗口", $endGiftHook.get()));
         ll.addView(subtitle(this, "消息通知设置(不影响接收消息)屏蔽后可能仍有[橙字],但通知栏不会有通知,赞说说不提醒仅屏蔽通知栏的通知"));
         ll.addView(subtitle(this, "    注:屏蔽后可能仍有[橙字],但不会有通知"));
-        ll.addView(_t = newListItemButton(this, "屏蔽指定群@全体成员通知", HtmlCompat.fromHtml("<font color='"
-                + get_RGB(hiColor.getDefaultColor()) + "'>[@全体成员]</font>就这点破事", FROM_HTML_MODE_LEGACY), "%d个群",
-            v -> TroopSelectActivity.startToSelectTroopsAndSaveToExfMgr(SettingsActivity.this, ConfigItems.qn_muted_at_all, "屏蔽@全体成员")));
-        __tv_muted_atall = _t.findViewById(R_ID_VALUE);
-        ll.addView(_t = newListItemButton(this, "屏蔽指定群的红包通知", HtmlCompat.fromHtml("<font color='"
-                + get_RGB(hiColor.getDefaultColor()) + "'>[QQ红包][有红包]</font>恭喜发财", FROM_HTML_MODE_LEGACY), "%d个群",
-            v -> TroopSelectActivity.startToSelectTroopsAndSaveToExfMgr(SettingsActivity.this, ConfigItems.qn_muted_red_packet, "屏蔽群红包")));
-        __tv_muted_redpacket = _t.findViewById(R_ID_VALUE);
         ll.addView(newListItemHookSwitchInit(this, "被赞说说不提醒", "不影响评论,转发或击掌的通知", MuteQZoneThumbsUp.get()));
         ll.addView(newListItemHookSwitchInit(this, "转发消息点头像查看详细信息", "仅限合并转发的消息", MultiForwardAvatarHook.get()));
         if (!HostInformationProviderKt.getHostInfo().isTim()) {

--- a/app/src/main/java/nil/nadph/qnotified/activity/SettingsActivity.java
+++ b/app/src/main/java/nil/nadph/qnotified/activity/SettingsActivity.java
@@ -233,9 +233,9 @@ public class SettingsActivity extends IphoneTitleBarActivityCompat implements Ru
         ll.addView(newListItemButtonIfValid(this, "精简加号菜单", null, null, SimplifyPlusPanel.INSTANCE));
         ll.addView(newListItemButtonIfValid(this, "精简设置菜单", null, null, SimplifyQQSettings.INSTANCE));
         ll.addView(newListItemHookSwitchInit(this, "批量撤回消息", "多选消息后撤回", MultiActionHook.INSTANCE));
-        ll.addView(newListItemButtonIfValid(this, "修改消息左滑动作", "", null, LeftSwipeReplyHook.INSTANCE, ModifyLeftSwipeReplyActivity.class));
+        ll.addView(newListItemButtonIfValid(this, "修改消息左滑动作", null, null, LeftSwipeReplyHook.INSTANCE, ModifyLeftSwipeReplyActivity.class));
         ll.addView(newListItemConfigSwitchIfValid(this, "修改@界面排序", "排序由群主管理员至正常人员", SortAtPanel.INSTANCE));
-        ll.addView(newListItemConfigSwitchIfValid(this, "发送收藏消息添加分组", "", SendFavoriteHook.INSTANCE));
+        ll.addView(newListItemConfigSwitchIfValid(this, "发送收藏消息添加分组", null, SendFavoriteHook.INSTANCE));
         ll.addView(subtitle(this, "好友列表"));
         ll.addView(newListItemButton(this, "打开资料卡", "打开指定用户的资料卡", null, new View.OnClickListener() {
             @Override


### PR DESCRIPTION
Signed-off-by: NextAlone <12210746+NextAlone@users.noreply.github.com>

# Add mute troop at all msg in AntiMessage and remove sth in SettingActivity

## 介绍 / Description
- Add mute troop at all msg in Anti Message
- Fix un-centered button in Settings Activity
- Remove mute at all and red pack in SettingsActivity which are abandoned temporarily

## 更改内容 / Types of Changes

- 修复 Bugfix
- 新功能 New Feature

## 检查列表 / Checklist

- [x] 我的代码符合本仓库的代码规范 My code follows the code style of this project
- [x] 我已经测试了这些更改，它们可以正常工作，既不会破坏原有任何功能(或我可以解决)，也不会影响对旧版本的支持 I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] 我已合并了对后续工作无意义的commit并确认不会对后续维护造成困扰 I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
