### PR TITLE
Fix NPE in Settings Activity caused by OnResume

### DIFF
--- a/app/src/main/java/nil/nadph/qnotified/activity/SettingsActivity.java
+++ b/app/src/main/java/nil/nadph/qnotified/activity/SettingsActivity.java
@@ -105,7 +105,7 @@ public class SettingsActivity extends IphoneTitleBarActivityCompat implements Ru
     private static final int R_ID_BTN_FILE_RECV = 0x300AFF91;
     private static final String qn_enable_fancy_rgb = "qn_enable_fancy_rgb";
 
-    private TextView __tv_muted_atall, __tv_muted_redpacket, __tv_fake_bat_status, __recv_status, __recv_desc, __jmp_ctl_cnt;
+    private TextView __tv_fake_bat_status, __recv_status, __recv_desc, __jmp_ctl_cnt;
 
     @Override
     public boolean doOnCreate(Bundle bundle) {
@@ -354,14 +354,6 @@ public class SettingsActivity extends IphoneTitleBarActivityCompat implements Ru
         super.doOnResume();
         ConfigManager cfg = ConfigManager.getDefaultConfig();//改这里的话可能会引发其他问题，所以只把红包和全体改了
         rgbEnabled = cfg.getBooleanOrFalse(qn_enable_fancy_rgb);
-        String str = ExfriendManager.getCurrent().getConfig().getString(ConfigItems.qn_muted_at_all);
-        int n = 0;
-        if (str != null && str.length() > 4) n = str.split(",").length;
-        __tv_muted_atall.setText(n + "个群");
-        str = ExfriendManager.getCurrent().getConfig().getString(ConfigItems.qn_muted_red_packet);
-        n = 0;
-        if (str != null && str.length() > 4) n = str.split(",").length;
-        __tv_muted_redpacket.setText(n + "个群");
         if (__tv_fake_bat_status != null) {
             FakeBatteryHook bat = FakeBatteryHook.get();
             if (bat.isEnabled()) {


### PR DESCRIPTION
# Fix NPE in Settings Activity caused by OnResume

## 更改内容 / Types of Changes

- 修复 Bugfix

## 检查列表 / Checklist

<!--- 遍历以下所有点并在下方的方框里输入x以生效-->
<!--- 如果你不确定，请不要犹豫，我们会为你提供帮助-->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] 我的代码符合本仓库的代码规范 My code follows the code style of this project
- [ ] 我已经测试了这些更改，它们可以正常工作，既不会破坏原有任何功能(或我可以解决)，也不会影响对旧版本的支持 I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] 我已合并了对后续工作无意义的commit并确认不会对后续维护造成困扰 I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
