### PR TITLE
Add Simplify Contact Tabs for QQ 8.5.5 

### DIFF
--- a/app/src/main/java/ltd/nextalone/hook/ChatWordsCount.kt
+++ b/app/src/main/java/ltd/nextalone/hook/ChatWordsCount.kt
@@ -160,7 +160,8 @@ object ChatWordsCount : CommonDelayableHook("na_chat_words_count_kt") {
         }
         val linearLayout = LinearLayout(ctx)
         linearLayout.orientation = LinearLayout.VERTICAL
-        linearLayout.addView(ViewBuilder.subtitle(activity, "%1表示发送消息总数，%2表示发送字数，%3表示发送表情包个数"))
+        linearLayout.addView(ViewBuilder.subtitle(activity, "替换侧滑栏个性签名为聊天字数统计，点击可更换字体颜色。"), ViewBuilder.newLinearLayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT, _5, 0, _5, 0))
+        linearLayout.addView(ViewBuilder.subtitle(activity, "%1表示发送消息总数，%2表示发送字数，%3表示发送表情包个数。"), ViewBuilder.newLinearLayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT, _5, 0, _5, 0))
         linearLayout.addView(checkBox, ViewBuilder.newLinearLayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT, _5 * 2))
         linearLayout.addView(editText, ViewBuilder.newLinearLayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT, _5 * 2))
         val alertDialog = dialog.setTitle("输入聊天字数统计样式")

--- a/app/src/main/java/ltd/nextalone/hook/SimplifyContactTabs.kt
+++ b/app/src/main/java/ltd/nextalone/hook/SimplifyContactTabs.kt
@@ -1,0 +1,74 @@
+/*
+ * QNotified - An Xposed module for QQ/TIM
+ * Copyright (C) 2019-2021 dmca@ioctl.cc
+ * https://github.com/ferredoxin/QNotified
+ *
+ * This software is non-free but opensource software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version and our eula as published
+ * by ferredoxin.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * and eula along with this software.  If not, see
+ * <https://www.gnu.org/licenses/>
+ * <https://github.com/ferredoxin/QNotified/blob/master/LICENSE.md>.
+ */
+package ltd.nextalone.hook
+
+import ltd.nextalone.base.MultiItemDelayableHook
+import ltd.nextalone.util.*
+import me.singleneuron.qn_kernel.data.requireMinQQVersion
+import me.singleneuron.util.QQVersion
+import nil.nadph.qnotified.util.Utils
+
+
+object SimplifyContactTabs : MultiItemDelayableHook("na_simplify_contact_tabs_kt", "保留") {
+    override val allItems = "好友|分组|群聊|设备|通讯录|订阅号".split("|").toMutableList()
+    override val defaultItems = "好友|分组|群聊|设备|通讯录|订阅号"
+
+    override fun initOnce(): Boolean {
+        return try {
+            "Lcom.tencent.mobileqq.activity.contacts.base.tabs.ContactsTabs;->a()V".method.hookAfter(this) {
+                val list = it.thisObject.get("a", ArrayList::class.java) as ArrayList<Any>
+                val tabList = list.toMutableList()
+                list.clear()
+                val stringList: ArrayList<String> = arrayListOf()
+                val intList: ArrayList<Int> = arrayListOf()
+                val cls = "com.tencent.mobileqq.activity.contacts.base.tabs.TabInfo".clazz
+                tabList.forEach { obj ->
+                    val str = obj.get("f") as String
+                    if (str == "好友" && activeItems.contains(str)) {
+                        val id = obj.get("d") as Int
+                        logAfter("obj:${obj.javaClass},id:$id,str:$str")
+                        list.add(obj)
+                        stringList.add(str)
+                        intList.add(id)
+                    } else if (activeItems.contains(str)) {
+                        val id = obj.get("d") as Int
+                        val instance = cls.instance(allItems.indexOf(str), id, str)
+                        logAfter("obj:${obj.javaClass},id:$id,str:$str")
+                        list.add(instance)
+                        stringList.add(str)
+                        intList.add(id)
+                    }
+                }
+                it.thisObject.set("a", Array<String>::class.java, stringList.toTypedArray())
+                it.thisObject.set("a", IntArray::class.java, intList.toIntArray())
+            }
+            true
+        } catch (t: Throwable) {
+            Utils.log(t)
+            false
+        }
+    }
+
+    override fun isValid() = requireMinQQVersion(QQVersion.QQ_8_5_5)
+
+    override fun isEnabled() = isValid && activeItems.size != allItems.size
+}

--- a/app/src/main/java/ltd/nextalone/util/Utils.kt
+++ b/app/src/main/java/ltd/nextalone/util/Utils.kt
@@ -1,3 +1,24 @@
+/*
+ * QNotified - An Xposed module for QQ/TIM
+ * Copyright (C) 2019-2021 dmca@ioctl.cc
+ * https://github.com/ferredoxin/QNotified
+ *
+ * This software is non-free but opensource software: you can redistribute it
+ * and/or modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version and our eula as published
+ * by ferredoxin.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * and eula along with this software.  If not, see
+ * <https://www.gnu.org/licenses/>
+ * <https://github.com/ferredoxin/QNotified/blob/master/LICENSE.md>.
+ */
 package ltd.nextalone.util
 
 import android.content.SharedPreferences
@@ -70,9 +91,15 @@ internal fun Member.replaceEmpty(baseHook: BaseDelayableHook) = this.replace(bas
     ""
 }
 
-internal fun Any?.get(objName: String, clz: Class<*>? = null): Any? {
-    return ReflexUtil.iget_object_or_null(this, objName, clz)
-}
+internal fun Any?.get(objName: String, clz: Class<*>? = null): Any? = ReflexUtil.iget_object_or_null(this, objName, clz)
+
+internal fun Any?.set(name: String, value: Any): Any = ReflexUtil.iput_object(this, name, value)
+
+internal fun Any?.set(name: String, clz: Class<*>?, value: Any): Any = ReflexUtil.iput_object(this, name, clz, value)
+
+internal fun Class<*>?.instance(vararg arg: Any?): Any = XposedHelpers.newInstance(this, *arg)
+
+internal fun Class<*>?.instance(type: Array<Class<*>>, vararg arg: Any?): Any = XposedHelpers.newInstance(this, type, *arg)
 
 internal fun Member.hook(callback: NAMethodHook) = try {
     XposedBridge.hookMethod(this, callback)

--- a/app/src/main/java/nil/nadph/qnotified/activity/SettingsActivity.java
+++ b/app/src/main/java/nil/nadph/qnotified/activity/SettingsActivity.java
@@ -66,6 +66,7 @@ import cc.ioctl.hook.RevokeMsgHook;
 import cc.ioctl.hook.RoundAvatarHook;
 import cc.ioctl.hook.ShowPicGagHook;
 import ltd.nextalone.hook.ChatWordsCount;
+import ltd.nextalone.hook.SimplifyContactTabs;
 import me.ketal.activity.ModifyLeftSwipeReplyActivity;
 import me.ketal.hook.ChatItemShowQQUin;
 import me.ketal.hook.FakeBalance;
@@ -230,6 +231,7 @@ public class SettingsActivity extends IphoneTitleBarActivityCompat implements Ru
         ll.addView(newListItemButtonIfValid(this, "精简聊天气泡长按菜单", null, null, SimplifyChatLongItem.INSTANCE, SimplifyChatLongItem.INSTANCE.listener()));
         ll.addView(newListItemButtonIfValid(this, "精简加号菜单", null, null, SimplifyPlusPanel.INSTANCE));
         ll.addView(newListItemButtonIfValid(this, "精简设置菜单", null, null, SimplifyQQSettings.INSTANCE));
+        ll.addView(newListItemButtonIfValid(this, "精简联系人页面", null, null, SimplifyContactTabs.INSTANCE));
         ll.addView(newListItemHookSwitchInit(this, "批量撤回消息", "多选消息后撤回", MultiActionHook.INSTANCE));
         ll.addView(newListItemButtonIfValid(this, "修改消息左滑动作", null, null, LeftSwipeReplyHook.INSTANCE, ModifyLeftSwipeReplyActivity.class));
         ll.addView(newListItemConfigSwitchIfValid(this, "修改@界面排序", "排序由群主管理员至正常人员", SortAtPanel.INSTANCE));

--- a/app/src/main/java/nil/nadph/qnotified/hook/AbsDelayableHook.java
+++ b/app/src/main/java/nil/nadph/qnotified/hook/AbsDelayableHook.java
@@ -78,6 +78,7 @@ import cc.ioctl.hook.SettingEntryHook;
 import cc.ioctl.hook.ShowPicGagHook;
 import cc.ioctl.hook.VasProfileAntiCrash;
 import ltd.nextalone.hook.ChatWordsCount;
+import ltd.nextalone.hook.SimplifyContactTabs;
 import me.ketal.hook.ChatItemShowQQUin;
 import me.ketal.hook.FakeBalance;
 import me.ketal.hook.HideAssistantRemoveTips;
@@ -238,7 +239,8 @@ public abstract class AbsDelayableHook implements SwitchConfigItem {
                 ChatWordsCount.INSTANCE,
                 QWalletNoAD.INSTANCE,
                 FakeBalance.INSTANCE,
-                ChatItemShowQQUin.INSTANCE
+                ChatItemShowQQUin.INSTANCE,
+                SimplifyContactTabs.INSTANCE,
             };
         }
         return sAllHooks;


### PR DESCRIPTION
# Add Simplify Contact Tabs for QQ 8.5.5 

## 介绍 / Description 

- Update NA Utils
- Add Simplify Contact Tabs for QQ 8.5.5
- Change Chat Words Count dialog margins and add desc 

## 更改内容 / Types of Changes

- 新功能 New Feature

## 检查列表 / Checklist

- [x] tested 