### PR TITLE
Use string instead of static class reference

### DIFF
--- a/app/src/main/java/nil/nadph/qnotified/startup/HookLoader.java
+++ b/app/src/main/java/nil/nadph/qnotified/startup/HookLoader.java
@@ -77,7 +77,7 @@ public class HookLoader implements IXposedHookLoadPackage {
     /**
      * 实际hook逻辑处理类
      */
-    private final String handleHookClass = HookEntry.class.getName();
+    private final String handleHookClass = "nil.nadph.qnotified.startup.HookEntry";
     /**
      * 实际hook逻辑处理类的入口方法
      */


### PR DESCRIPTION
Signed-off-by: Null Idle <xenonhydride@gmail.com>

Use string instead of static class reference