### PR TITLE
fix: Emoji2Sticker crash

### DIFF
--- a/app/src/main/java/me/ketal/hook/Emoji2Sticker.kt
+++ b/app/src/main/java/me/ketal/hook/Emoji2Sticker.kt
@@ -35,7 +35,7 @@ import nil.nadph.qnotified.hook.CommonDelayableHook
 import nil.nadph.qnotified.util.QQVersion
 
 @FunctionEntry
-object Emoji2Sticker : CommonDelayableHook("Ketal_Emoji2Sticker", SyncUtils.PROC_MAIN, true) {
+object Emoji2Sticker : CommonDelayableHook("Ketal_Emoji2Sticker", SyncUtils.PROC_MAIN, false) {
     override fun isValid() = requireMinQQVersion(QQVersion.QQ_8_7_5)
 
     override fun initOnce() = tryOrFalse {
@@ -47,9 +47,11 @@ object Emoji2Sticker : CommonDelayableHook("Ketal_Emoji2Sticker", SyncUtils.PROC
             }
     }
 
-    fun superIsEnable() = super.isEnabled()
+    fun superIsEnable(): Boolean {
+        return isValid && super.isEnabled()
+    }
 
-    override fun isEnabled() = true
+    override fun isEnabled() = isValid
 
     fun parseMsgForAniSticker(str: String, session: Any) : Any? {
         return try {

--- a/app/src/main/java/nil/nadph/qnotified/util/ReflexUtil.java
+++ b/app/src/main/java/nil/nadph/qnotified/util/ReflexUtil.java
@@ -807,8 +807,8 @@ public class ReflexUtil {
     }
 
     public static <T> T iget_object_or_null(Object obj, String name, Class<T> type) {
-        Class clazz = obj.getClass();
         try {
+            Class clazz = obj.getClass();
             Field f = findField(clazz, type, name);
             f.setAccessible(true);
             return (T) f.get(obj);


### PR DESCRIPTION
When Emoji2Sticker missing unsupported version, and send is button long clicked. ALso fixed iget_object_or_null's getClass which could cause NPE

Signed-off-by: singleNeuron <Cryolitia@gmail.com>

## 更改内容 / Types of Changes

<!--- 你的代码更改了哪部分的内容? (将没有改动的要点删除) -->
- 修复 Bugfix

## 检查列表 / Checklist

- [x] 我的代码符合本仓库的代码规范 My code follows the code style of this project
- [x] 我已经测试了这些更改，它们可以正常工作，既不会破坏原有任何功能(或我可以解决)，也不会影响对旧版本的支持 I have tested the changes and verified that they work and don't break anything(as well as I can manage) or drop the support for previous versions.
- [x] 我已合并了对后续工作无意义的commit并确认不会对后续维护造成困扰 I have merged commits that are meaningless for follow-up work and confirmed that they will not cause damage to follow-up maintenance
