### PR TITLE
优化系统相册的调用，并在选择文件时支持需要进入应用界面选择的应用

### DIFF
--- a/app/src/main/java/me/singleneuron/activity/ChooseAgentActivity.kt
+++ b/app/src/main/java/me/singleneuron/activity/ChooseAgentActivity.kt
@@ -25,8 +25,7 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.ComponentName
 import android.content.Intent
-import android.content.Intent.ACTION_OPEN_DOCUMENT
-import android.content.Intent.EXTRA_ALLOW_MULTIPLE
+import android.content.Intent.*
 import android.os.Bundle
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.Dispatchers
@@ -41,8 +40,11 @@ class ChooseAgentActivity : AbstractChooseActivity() {
         setTheme(R.style.noDisplay)
         super.onCreate(savedInstanceState)
         bundle = intent.extras
-        val intent = Intent(ACTION_OPEN_DOCUMENT).apply {
-            type = intent.type ?: "*/*"
+        val intent = if (intent.type == "image/*") Intent(ACTION_PICK).apply {
+            type = "image/*"
+            putExtra(EXTRA_ALLOW_MULTIPLE, false)
+        } else Intent(ACTION_GET_CONTENT).apply {
+            type = "*/*"
             putExtra(EXTRA_ALLOW_MULTIPLE, false)
         }
         startActivityForResult(intent, REQUEST_CODE)

--- a/app/src/main/java/me/singleneuron/activity/ChooseAgentActivity.kt
+++ b/app/src/main/java/me/singleneuron/activity/ChooseAgentActivity.kt
@@ -40,11 +40,13 @@ class ChooseAgentActivity : AbstractChooseActivity() {
         setTheme(R.style.noDisplay)
         super.onCreate(savedInstanceState)
         bundle = intent.extras
-        val intent = if (intent.type == "image/*") Intent(ACTION_PICK).apply {
-            type = "image/*"
-            putExtra(EXTRA_ALLOW_MULTIPLE, false)
-        } else Intent(ACTION_GET_CONTENT).apply {
-            type = "*/*"
+        val intent = if (intent.getBooleanExtra("use_ACTION_PICK", false))
+            Intent(ACTION_PICK).apply {
+                type = "image/*"
+                putExtra(EXTRA_ALLOW_MULTIPLE, false)
+            }
+        else Intent(ACTION_GET_CONTENT).apply {
+            type = intent.type ?: "*/*"
             putExtra(EXTRA_ALLOW_MULTIPLE, false)
         }
         startActivityForResult(intent, REQUEST_CODE)

--- a/app/src/main/java/me/singleneuron/hook/decorator/ForceSystemAlbum.kt
+++ b/app/src/main/java/me/singleneuron/hook/decorator/ForceSystemAlbum.kt
@@ -47,6 +47,12 @@ object ForceSystemAlbum : BaseStartActivityHookDecorator() {
             val activityMap = mapOf(
                 "系统相册" to Intent(context, ChooseAgentActivity::class.java).apply {
                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    putExtra("use_ACTION_PICK", true)
+                    putExtras(intent)
+                    type = "image/*"
+                },
+                "系统文档" to Intent(context, ChooseAgentActivity::class.java).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                     putExtras(intent)
                     type = "image/*"
                 },

--- a/app/src/main/java/me/singleneuron/hook/decorator/ForceSystemAlbum.kt
+++ b/app/src/main/java/me/singleneuron/hook/decorator/ForceSystemAlbum.kt
@@ -76,7 +76,7 @@ object ForceSystemAlbum : BaseStartActivityHookDecorator() {
     }
 
     override val preference = uiSwitchPreference {
-        title = "强制使用系统相册"
+        title = "可选使用系统相册"
         summary = "支持8.3.6及更高"
     }
 


### PR DESCRIPTION
# PR

## 介绍

在选取图片的时候，使用 `ACTION_PICK` 来选择图片，这可以调用系统的相册（比如说谷歌相册或者厂家系统的相册）来选择图片，而不是系统的「文档」应用

在选择文件时，使用 `ACTION_GET_CONTENT` 代替 `ACTION_OPEN_DOCUMENT`，这可以在选择文件时支持需要进入应用界面选择的应用，如下图所示

![image](https://user-images.githubusercontent.com/18461360/150728458-426ae2e5-4c4c-4df0-b219-7038982011d1.png)

## 检查列表

- [x] Tested
