### PR TITLE
fix: Cannot use system picker to send files in TIM

### DIFF
--- a/app/src/main/java/me/singleneuron/activity/ChooseAgentActivity.kt
+++ b/app/src/main/java/me/singleneuron/activity/ChooseAgentActivity.kt
@@ -92,7 +92,7 @@ class ChooseAgentActivity : AbstractChooseActivity() {
     fun sendAFile(filePath: String, data: Intent) {
         val intent = Intent().apply {
             component = ComponentName(
-                "com.tencent.mobileqq",
+                application.packageName,
                 "com.tencent.mobileqq.activity.SplashActivity"
             )
             flags = 0x14000000


### PR DESCRIPTION
# PR

## 介绍

修复在 TIM 里面无法使用系统选择器

其实是包名写死了 QQ，选择之后把请求传给 QQ 应用了。要是没有安装 QQ 的话还会闪退

## 检查列表

- [x] Tested
